### PR TITLE
📚 v1.0.1: READMEの設定例を改善

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -48,10 +48,11 @@ MCP クライアント(Claude Desktop、Cline など)でこのサーバーを使
 ```json
 {
   "mcpServers": {
-    "mysql": {
+    "mysql-mcp-server": {
       "command": "npx",
       "args": [
-        "@yukihito/mysql-mcp-server",
+        "-y",
+        "@yukihito/mysql-mcp-server@latest",
         "--host", "localhost",
         "--port", "3306",
         "--name", "your_username",
@@ -84,10 +85,11 @@ Claude Desktop の設定ファイルを編集します:
 ```json
 {
   "mcpServers": {
-    "mysql": {
+    "mysql-mcp-server": {
       "command": "npx",
       "args": [
-        "@yukihito/mysql-mcp-server",
+        "-y",
+        "@yukihito/mysql-mcp-server@latest",
         "--host", "localhost",
         "--port", "3306",
         "--name", "myuser",

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ Configure your MCP client (e.g., Claude Desktop, Cline) to use this server:
 ```json
 {
   "mcpServers": {
-    "mysql": {
+    "mysql-mcp-server": {
       "command": "npx",
       "args": [
-        "@yukihito/mysql-mcp-server",
+        "-y",
+        "@yukihito/mysql-mcp-server@latest",
         "--host", "localhost",
         "--port", "3306",
         "--name", "your_username",
@@ -84,10 +85,11 @@ Edit your Claude Desktop configuration file:
 ```json
 {
   "mcpServers": {
-    "mysql": {
+    "mysql-mcp-server": {
       "command": "npx",
       "args": [
-        "@yukihito/mysql-mcp-server",
+        "-y",
+        "@yukihito/mysql-mcp-server@latest",
         "--host", "localhost",
         "--port", "3306",
         "--name", "myuser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yukihito/mysql-mcp-server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "mcpName": "io.github.yukihito-jokyu/mysql-mcp-server",
   "description": "MySQL MCP Server",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yukihito/mysql-mcp-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "mcpName": "io.github.yukihito-jokyu/mysql-mcp-server",
   "description": "MySQL MCP Server",
   "private": false,


### PR DESCRIPTION
# チケット

特になし

# 概要

v1.0.1のリリースに伴い、READMEの設定例を改善しました。

## 変更内容

### バージョン更新
- package.jsonのバージョンを1.0.0から1.0.1に更新

### README設定例の改善
以下の3点を改善し、ユーザーがより簡単に設定できるようにしました：

1. **MCPサーバー名の明確化**
   - `"mysql"` → `"mysql-mcp-server"`
   - パッケージ名と一致させることで、設定の意図をより明確にしました

2. **npxコマンドの自動承認**
   - `-y` フラグを追加
   - パッケージインストール時の確認プロンプトをスキップし、スムーズな実行を実現

3. **バージョン指定の明示化**
   - `@yukihito/mysql-mcp-server` → `@yukihito/mysql-mcp-server@latest`
   - 常に最新バージョンを使用することを明示

## 影響範囲
- README.md（英語版）
- README.ja.md（日本語版）

## 背景
v1.0.0のリリース後、ユーザーがより簡単に設定できるよう、ベストプラクティスに基づいた設定例に更新しました。

# その他
特になし